### PR TITLE
ヘッダー・サイドナビを全画面で表示

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,35 @@
+<header>
+  <mat-sidenav-container class="sidenav">
+    <mat-sidenav #sidenav mode="over">
+      <mat-nav-list>
+        <a routerLink="/home" routerLinkActive="active" mat-list-item>ホーム</a>
+        <a mat-list-item>プロフィール</a>
+        <a mat-list-item>設定</a>
+      </mat-nav-list>
+      <mat-divider></mat-divider>
+      <mat-nav-list>
+        <a routerLink="/terms" routerLinkActive="active" mat-list-item
+          >利用規約</a
+        >
+        <a routerLink="/legal" routerLinkActive="active" mat-list-item
+          >特定商取引法に基づく表記</a
+        >
+      </mat-nav-list>
+      <mat-divider></mat-divider>
+      <div>
+        <p class="sidenav__copyright">© 2020 Hideki Arima</p>
+      </div>
+    </mat-sidenav>
+
+    <mat-sidenav-content>
+      <mat-toolbar>
+        <button mat-icon-button (click)="sidenav.toggle()">
+          <mat-icon>menu</mat-icon>
+        </button>
+        <p class="sidenav__app-name">Logo</p>
+        <button mat-button>Login</button>
+      </mat-toolbar>
+    </mat-sidenav-content>
+  </mat-sidenav-container>
+</header>
 <router-outlet></router-outlet>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,14 @@
+.sidenav {
+  height: 100%;
+  display: flex;
+  position: static;
+  flex-direction: column;
+  &__copyright {
+    color: rgba(0, 0, 0, 0.38);
+    font-size: 13px;
+    padding: 16px;
+  }
+  &__app-name {
+    margin: 10px auto;
+  }
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,13 @@ import { AngularFirestoreModule } from '@angular/fire/firestore';
 import { AngularFireStorageModule } from '@angular/fire/storage';
 import { AngularFireAuthModule } from '@angular/fire/auth';
 import { MatButtonModule } from '@angular/material/button';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatListModule } from '@angular/material/list';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatNativeDateModule, MatRippleModule } from '@angular/material/core';
+import { MatSidenavModule } from '@angular/material/sidenav';
 
 @NgModule({
   declarations: [AppComponent],
@@ -25,6 +32,14 @@ import { MatButtonModule } from '@angular/material/button';
     AngularFireAuthModule,
     AngularFireFunctionsModule,
     MatButtonModule,
+    MatToolbarModule,
+    MatIconModule,
+    MatInputModule,
+    MatListModule,
+    MatMenuModule,
+    MatNativeDateModule,
+    MatRippleModule,
+    MatSidenavModule,
   ],
   providers: [{ provide: REGION, useValue: 'asia-northeast1' }],
   bootstrap: [AppComponent],

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -3,27 +3,10 @@ import { CommonModule } from '@angular/common';
 
 import { HomeRoutingModule } from './home-routing.module';
 import { HomeComponent } from './home/home.component';
-import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatIconModule } from '@angular/material/icon';
-import { MatInputModule } from '@angular/material/input';
-import { MatListModule } from '@angular/material/list';
-import { MatMenuModule } from '@angular/material/menu';
-import { MatNativeDateModule, MatRippleModule } from '@angular/material/core';
-import { MatSidenavModule } from '@angular/material/sidenav';
 
 @NgModule({
   declarations: [HomeComponent],
-  imports: [
-    CommonModule,
-    HomeRoutingModule,
-    MatToolbarModule,
-    MatIconModule,
-    MatInputModule,
-    MatListModule,
-    MatMenuModule,
-    MatNativeDateModule,
-    MatRippleModule,
-    MatSidenavModule,
-  ],
+  imports: [CommonModule, HomeRoutingModule, MatIconModule],
 })
 export class HomeModule {}

--- a/src/app/home/home/home.component.html
+++ b/src/app/home/home/home.component.html
@@ -1,36 +1,3 @@
-<mat-sidenav-container class="sidenav">
-  <mat-sidenav #sidenav mode="over">
-    <mat-nav-list>
-      <a routerLink="/home" routerLinkActive="active" mat-list-item>ホーム</a>
-      <a mat-list-item>プロフィール</a>
-      <a mat-list-item>設定</a>
-    </mat-nav-list>
-    <mat-divider></mat-divider>
-    <mat-nav-list>
-      <a routerLink="/terms" routerLinkActive="active" mat-list-item
-        >利用規約</a
-      >
-      <a routerLink="/legal" routerLinkActive="active" mat-list-item
-        >特定商取引法に基づく表記</a
-      >
-    </mat-nav-list>
-    <mat-divider></mat-divider>
-    <div>
-      <p class="sidenav__copyright">© 2020 Hideki Arima</p>
-    </div>
-  </mat-sidenav>
-
-  <mat-sidenav-content>
-    <mat-toolbar>
-      <button mat-icon-button (click)="sidenav.toggle()">
-        <mat-icon>menu</mat-icon>
-      </button>
-      <p class="sidenav__app-name">Logo</p>
-      <button mat-button>Login</button>
-    </mat-toolbar>
-  </mat-sidenav-content>
-</mat-sidenav-container>
-
 <div class="home">
   <div class="home__mountain-name">
     <h1>天城山</h1>
@@ -45,8 +12,7 @@
   <div class="home__sort">検索</div>
   <div class="timeline">タイムライン</div>
   <div class="form">
-    <!-- formに飛ばす予定、仮にlegalに飛ぶ -->
-    <button mat-icon-button routerLink="/legal" routerLinkActive="active">
+    <button mat-icon-button routerLink="/form" routerLinkActive="active">
       <mat-icon>comment</mat-icon>
     </button>
   </div>

--- a/src/app/home/home/home.component.scss
+++ b/src/app/home/home/home.component.scss
@@ -1,16 +1,3 @@
-.sidenav {
-  display: flex;
-  flex-direction: column;
-  &__copyright {
-    color: rgba(0, 0, 0, 0.38);
-    font-size: 13px;
-    padding: 16px;
-  }
-  &__app-name {
-    margin: 10px auto;
-  }
-}
-
 .home {
   text-align: center;
 }


### PR DESCRIPTION
fix #33 
## detail
homeページにしか存在していなかったヘッダー・サイドナビを全ページで表示されるように変更しました。
ご確認お願いいたします。
## image
### home
![image](https://user-images.githubusercontent.com/60844124/81783922-0d791380-9537-11ea-8e2e-21b73ef7f6c4.png)


### terms
![image](https://user-images.githubusercontent.com/60844124/81783983-2386d400-9537-11ea-9a26-06ca18c50bcf.png)
