### PR TITLE
フォームラベル追加・Firestoreにデータを追加する処理

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,11 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
-      allow read, write: if false;
+    match /posts/{postId} {
+      allow read: if true;
+      allow create: if request.auth.uid != null;
+      allow update: if request.auth.uid == resource.data.userId && resource.data.userId == request.resource.data.trainerId;
+      allow delete: if request.auth.uid == resource.data.userId;
     }
   }
 }

--- a/src/app/form/form.module.ts
+++ b/src/app/form/form.module.ts
@@ -6,6 +6,7 @@ import { FormComponent } from './form/form.component';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { MatRadioModule } from '@angular/material/radio';
 
 @NgModule({
   declarations: [FormComponent],
@@ -16,6 +17,7 @@ import { MatInputModule } from '@angular/material/input';
     FormsModule,
     MatFormFieldModule,
     MatInputModule,
+    MatRadioModule,
   ],
 })
 export class FormModule {}

--- a/src/app/form/form/form.component.html
+++ b/src/app/form/form/form.component.html
@@ -7,7 +7,7 @@
     ></iframe>
   </div>
   <form [formGroup]="form" class="form__form" (ngSubmit)="submit()">
-    <mat-radio-group formControlName="rabel">
+    <mat-radio-group formControlName="label">
       <mat-radio-button value="denger">危険箇所</mat-radio-button>
       <mat-radio-button value="viewPoint">絶景ポイント</mat-radio-button>
       <mat-radio-button value="toilet">お手洗い</mat-radio-button>
@@ -17,11 +17,20 @@
     <mat-form-field>
       <mat-label>Textarea</mat-label>
       <textarea
+        type="text"
         formControlName="content"
         placeholder="test"
         matInput
       ></textarea>
+      <mat-error *ngIf="contentControl.hasError('required')"
+        >必須入力です</mat-error
+      >
+      <mat-error *ngIf="contentControl.hasError('maxlength')"
+        >長すぎます</mat-error
+      >
     </mat-form-field>
-    <button mat-raised-button color="primary">投稿</button>
+    <button [disabled]="form.invalid" mat-raised-button color="primary">
+      投稿
+    </button>
   </form>
 </div>

--- a/src/app/form/form/form.component.html
+++ b/src/app/form/form/form.component.html
@@ -2,7 +2,7 @@
   <div class="form__map">
     <iframe
       src="https://www.google.com/maps/d/embed?mid=1-Uov2ANGKaYKUV207hf7LgPu6XZFnwzp"
-      width="375"
+      width="100%"
       height="300"
     ></iframe>
   </div>
@@ -17,6 +17,7 @@
     <mat-form-field>
       <mat-label>Textarea</mat-label>
       <textarea
+        matTextareaAutosize
         type="text"
         formControlName="content"
         placeholder="test"

--- a/src/app/form/form/form.component.html
+++ b/src/app/form/form/form.component.html
@@ -30,7 +30,7 @@
         >長すぎます</mat-error
       >
     </mat-form-field>
-    <button [disabled]="form.invalid" mat-raised-button color="primary">
+    <button mat-raised-button color="primary" [disabled]="form.invalid">
       投稿
     </button>
   </form>

--- a/src/app/form/form/form.component.html
+++ b/src/app/form/form/form.component.html
@@ -7,6 +7,13 @@
     ></iframe>
   </div>
   <form [formGroup]="form" class="form__form" (ngSubmit)="submit()">
+    <mat-radio-group formControlName="rabel">
+      <mat-radio-button value="denger">危険箇所</mat-radio-button>
+      <mat-radio-button value="viewPoint">絶景ポイント</mat-radio-button>
+      <mat-radio-button value="toilet">お手洗い</mat-radio-button>
+      <mat-radio-button value="water">水場</mat-radio-button>
+      <mat-radio-button value="rest">休憩ポイント</mat-radio-button>
+    </mat-radio-group>
     <mat-form-field>
       <mat-label>Textarea</mat-label>
       <textarea

--- a/src/app/form/form/form.component.scss
+++ b/src/app/form/form/form.component.scss
@@ -1,0 +1,3 @@
+mat-form-field {
+  width: 100%;
+}

--- a/src/app/form/form/form.component.ts
+++ b/src/app/form/form/form.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, Validators, FormControl } from '@angular/forms';
+import { PostService } from 'src/app/services/post.service';
+import { AuthService } from 'src/app/services/auth.service';
 
 @Component({
   selector: 'app-form',
@@ -18,7 +20,11 @@ export class FormComponent implements OnInit {
     content: ['', [Validators.required, Validators.maxLength(1000)]],
   });
 
-  constructor(private fb: FormBuilder) {}
+  constructor(
+    private fb: FormBuilder,
+    private postService: PostService,
+    private authService: AuthService
+  ) {}
 
   ngOnInit(): void {}
 
@@ -27,6 +33,11 @@ export class FormComponent implements OnInit {
   }
 
   submit() {
-    console.log(this.form.value);
+    const formData = this.form.value;
+    this.postService.createPost({
+      uid: this.authService.uid,
+      label: formData.label,
+      content: formData.content,
+    });
   }
 }

--- a/src/app/form/form/form.component.ts
+++ b/src/app/form/form/form.component.ts
@@ -35,7 +35,7 @@ export class FormComponent implements OnInit {
   submit() {
     const formData = this.form.value;
     this.postService.createPost({
-      uid: this.authService.uid,
+      userId: this.authService.userId,
       label: formData.label,
       content: formData.content,
     });

--- a/src/app/form/form/form.component.ts
+++ b/src/app/form/form/form.component.ts
@@ -8,6 +8,13 @@ import { FormBuilder, Validators } from '@angular/forms';
 })
 export class FormComponent implements OnInit {
   form = this.fb.group({
+    rabel: [
+      '',
+      [
+        Validators.required,
+        Validators.pattern(/denger|viewPoint|toiler|water|rest/),
+      ],
+    ],
     content: ['', [Validators.required, Validators.maxLength(1000)]],
   });
 

--- a/src/app/form/form/form.component.ts
+++ b/src/app/form/form/form.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder, Validators } from '@angular/forms';
+import { FormBuilder, Validators, FormControl } from '@angular/forms';
 
 @Component({
   selector: 'app-form',
@@ -8,7 +8,7 @@ import { FormBuilder, Validators } from '@angular/forms';
 })
 export class FormComponent implements OnInit {
   form = this.fb.group({
-    rabel: [
+    label: [
       '',
       [
         Validators.required,
@@ -21,6 +21,10 @@ export class FormComponent implements OnInit {
   constructor(private fb: FormBuilder) {}
 
   ngOnInit(): void {}
+
+  get contentControl(): FormControl {
+    return this.form.get('content') as FormControl;
+  }
 
   submit() {
     console.log(this.form.value);

--- a/src/app/interfaces/form.ts
+++ b/src/app/interfaces/form.ts
@@ -1,0 +1,1 @@
+export interface Form {}

--- a/src/app/interfaces/form.ts
+++ b/src/app/interfaces/form.ts
@@ -1,1 +1,0 @@
-export interface Form {}

--- a/src/app/interfaces/post.ts
+++ b/src/app/interfaces/post.ts
@@ -1,5 +1,5 @@
 export interface Post {
-  uid: string;
+  userId: string;
   label: string;
   content: string;
 }

--- a/src/app/interfaces/post.ts
+++ b/src/app/interfaces/post.ts
@@ -1,0 +1,5 @@
+export interface Post {
+  uid: string;
+  label: string;
+  content: string;
+}

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -10,12 +10,16 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 })
 export class AuthService {
   afUser$: Observable<User> = this.afAuth.user;
+  uid: string;
+
   constructor(
     private afAuth: AngularFireAuth,
     private router: Router,
     private snackBar: MatSnackBar
   ) {
-    this.afUser$.subscribe((user) => console.log(user));
+    this.afUser$.subscribe((user) => {
+      this.uid = user && user.uid;
+    });
   }
 
   login() {

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -10,7 +10,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 })
 export class AuthService {
   afUser$: Observable<User> = this.afAuth.user;
-  uid: string;
+  userId: string;
 
   constructor(
     private afAuth: AngularFireAuth,
@@ -18,7 +18,7 @@ export class AuthService {
     private snackBar: MatSnackBar
   ) {
     this.afUser$.subscribe((user) => {
-      this.uid = user && user.uid;
+      this.userId = user && user.uid;
     });
   }
 

--- a/src/app/services/post.service.spec.ts
+++ b/src/app/services/post.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PostService } from './post.service';
+
+describe('PostService', () => {
+  let service: PostService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PostService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/post.service.ts
+++ b/src/app/services/post.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PostService {
+  constructor() {}
+}

--- a/src/app/services/post.service.ts
+++ b/src/app/services/post.service.ts
@@ -1,8 +1,23 @@
 import { Injectable } from '@angular/core';
+import { AngularFirestore } from '@angular/fire/firestore';
+import { Post } from '../interfaces/post';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Injectable({
   providedIn: 'root',
 })
 export class PostService {
-  constructor() {}
+  constructor(private db: AngularFirestore, private snackBar: MatSnackBar) {}
+
+  createPost(post: Post) {
+    const id = this.db.createId();
+    this.db
+      .doc(`posts/${id}`)
+      .set(post)
+      .then(() => {
+        this.snackBar.open('投稿しました', null, {
+          duration: 2000,
+        });
+      });
+  }
 }

--- a/src/app/services/post.service.ts
+++ b/src/app/services/post.service.ts
@@ -2,12 +2,17 @@ import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/firestore';
 import { Post } from '../interfaces/post';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
 
 @Injectable({
   providedIn: 'root',
 })
 export class PostService {
-  constructor(private db: AngularFirestore, private snackBar: MatSnackBar) {}
+  constructor(
+    private db: AngularFirestore,
+    private snackBar: MatSnackBar,
+    private router: Router
+  ) {}
 
   createPost(post: Post) {
     const id = this.db.createId();
@@ -18,6 +23,7 @@ export class PostService {
         this.snackBar.open('投稿しました', null, {
           duration: 2000,
         });
+        this.router.navigateByUrl('/');
       });
   }
 }


### PR DESCRIPTION
fixes #40 #39 

## details
フォーム画面にラベル追加・テキストエリアの修正を行い、投稿ボタンを押すとfirestoreにデータが追加されるようにしました。
ご確認お願いいたします。

## image
![image](https://user-images.githubusercontent.com/60844124/82171056-2bf95900-9901-11ea-84d9-477b44fb83f8.png)
![image](https://user-images.githubusercontent.com/60844124/82173890-d1b0c600-9909-11ea-91c7-748b7dbbc801.png)

