### PR TITLE
ユーザー未認証時に投稿ボタン/プロフィール・設定リンクを非表示

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -21,8 +21,8 @@
     >
       <mat-nav-list>
         <a routerLink="" routerLinkActive="active" mat-list-item>ホーム</a>
-        <a mat-list-item>プロフィール</a>
-        <a mat-list-item>設定</a>
+        <a *ngIf="user$ | async" mat-list-item>プロフィール</a>
+        <a *ngIf="user$ | async" mat-list-item>設定</a>
       </mat-nav-list>
       <mat-divider></mat-divider>
       <mat-nav-list>

--- a/src/app/home/home/home.component.html
+++ b/src/app/home/home/home.component.html
@@ -10,7 +10,7 @@
         height="200"
       ></iframe>
     </div>
-    <div class="home__formLink">
+    <div *ngIf="user$ | async" class="home__formLink">
       <button
         mat-fab
         color="primary"

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -4,6 +4,7 @@ import { SearchIndex } from 'algoliasearch/lite';
 import { FormControl } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 import { UiService } from 'src/app/services/ui.service';
+import { AuthService } from 'src/app/services/auth.service';
 
 @Component({
   selector: 'app-home',
@@ -19,12 +20,14 @@ export class HomeComponent implements OnInit {
   loading: boolean;
   requestOptions: any = {};
   searchQuery: string;
+  user$ = this.authService.afUser$;
 
   constructor(
     public searchService: SearchService,
     private router: Router,
     private route: ActivatedRoute,
-    public uiService: UiService
+    public uiService: UiService,
+    private authService: AuthService
   ) {
     this.route.queryParamMap.subscribe((param) => {
       this.searchQuery = param.get('searchQuery') || '';

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -11,7 +11,6 @@ import { AngularFirestore } from '@angular/fire/firestore';
   providedIn: 'root',
 })
 export class AuthService {
-  // afUser$: Observable<User> = this.afAuth.user; // 後で消去
   userId: string;
 
   afUser$: Observable<User> = this.afAuth.authState.pipe(


### PR DESCRIPTION
ユーザー未認証時には入れない画面へのリンクを非表示にするよう変更しました。
ご確認お願いいたします。

## image
ログイン時
![image](https://user-images.githubusercontent.com/60844124/87271547-7c122780-c50e-11ea-98a1-8f9050818fa0.png)
ログアウト時
![image](https://user-images.githubusercontent.com/60844124/87271562-86ccbc80-c50e-11ea-9c52-f75d5540fca6.png)

## 
認証の処理の理解があいまいだったので、自分なりに理解したところにコメントを付けてみました。間違っているところがあればご指摘お願いしたいです。よろしくお願いいたします。

```ts
export class AuthService {
  // observableを流したくない時にuidを渡すための変数
  userId: string;
  //  this.afAuth.authStateで認証状態を確認、認証済であればユーザー情報が入ってくる、未認証であればnullが入る
  afUser$: Observable<User> = this.afAuth.authState.pipe(
    switchMap((afUser) => {
      if (afUser) {
        // user情報全体のobservableをuser情報の中のuidだけをながすobservableに変換する処理
        return this.db.doc<User>(`users/${afUser.uid}`).valueChanges();
      } else {
        return of(null);
      }
    })
  );

  constructor(
    private db: AngularFirestore,
    private afAuth: AngularFireAuth,
    private router: Router,
    private snackBar: MatSnackBar
  ) {
    // observableではなくstringでuseridを受け取れるようにするための処理(gitpetのFirestoreにデータを追加する09:10付近の処理をトレースしたもの)
    // user && user.uid の意味はuserがいればuser.uidを入れるということ
    this.afUser$.subscribe((user) => {
      this.userId = user && user.uid;
    });
  }
```
##
fix #104 
fix #105 