### PR TITLE
カードにユーザー情報を表示させる

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -19,7 +19,7 @@ export class AppComponent implements AfterViewInit {
   @ViewChild('wrap') private wrap: MatSidenavContent;
 
   title = 'yama-portal';
-  user$ = this.authService.afUser$;
+  user$ = this.authService.user$;
   opened: boolean;
 
   constructor(

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -26,7 +26,7 @@ export class AuthGuard implements CanActivate, CanLoad {
     | Promise<boolean | UrlTree>
     | boolean
     | UrlTree {
-    return this.authService.afUser$.pipe(
+    return this.authService.user$.pipe(
       map((user) => !!user),
       tap((isLoggedIn) => {
         if (!isLoggedIn) {
@@ -39,7 +39,7 @@ export class AuthGuard implements CanActivate, CanLoad {
     route: Route,
     segments: UrlSegment[]
   ): Observable<boolean> | Promise<boolean> | boolean {
-    return this.authService.afUser$.pipe(
+    return this.authService.user$.pipe(
       map((user) => !!user),
       take(1),
       tap((isLoggedin) => {

--- a/src/app/guards/guest.guard.ts
+++ b/src/app/guards/guest.guard.ts
@@ -27,7 +27,7 @@ export class GuestGuard implements CanActivate, CanLoad {
     | Promise<boolean | UrlTree>
     | boolean
     | UrlTree {
-    return this.authService.afUser$.pipe(
+    return this.authService.user$.pipe(
       map((user) => !user),
       tap((isGuest) => {
         if (!isGuest) {
@@ -40,7 +40,7 @@ export class GuestGuard implements CanActivate, CanLoad {
     route: Route,
     segments: UrlSegment[]
   ): Observable<boolean> | Promise<boolean> | boolean {
-    return this.authService.afUser$.pipe(
+    return this.authService.user$.pipe(
       map((user) => !user),
       take(1),
       tap((isGuest) => {

--- a/src/app/home/home/home.component.html
+++ b/src/app/home/home/home.component.html
@@ -36,10 +36,14 @@
   </form>
 
   <div class="timeLine">
-    <mat-card *ngFor="let item of items" class="card">
+    <mat-card *ngFor="let item of posts" class="card">
       <mat-card-header>
-        <div mat-card-avatar class="card__avatar"></div>
-        <mat-card-title>UserName</mat-card-title>
+        <div
+          mat-card-avatar
+          [style.background-image]="'url(' + item.user.avaterURL + ')'"
+          class="card__avatar"
+        ></div>
+        <mat-card-title>{{ item.user.name }}</mat-card-title>
         <mat-card-subtitle>{{ item.label }}</mat-card-subtitle>
       </mat-card-header>
       <a href="{{ item.imageURL }}">

--- a/src/app/home/home/home.component.scss
+++ b/src/app/home/home/home.component.scss
@@ -107,13 +107,7 @@ img {
     align-items: center;
   }
   &__avatar {
-    border-radius: 50%;
-    width: 40px;
-    height: 40px;
-    background: #000;
-    margin-right: 16px;
-    background: #000 center/cover;
-    background-image: url(#);
+    background: center/cover;
   }
   &__title {
     margin-bottom: 4px;

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -17,7 +17,7 @@ export class HomeComponent implements OnInit {
   searchControl: FormControl = new FormControl('');
   page: 0;
   posts: PostWithUser[] = [];
-  maxPage: number = 5;
+  maxPage = 5;
   loading: boolean;
   requestOptions: any = {};
   searchQuery: string;
@@ -47,10 +47,11 @@ export class HomeComponent implements OnInit {
     };
     this.searchService
       .getPostWithUser(this.searchQuery, searchOptions)
-      .then(async (result) => {
-        const items = await result.pipe(take(1)).toPromise();
-
-        this.posts.push(...items);
+      .then((result) => {
+        result
+          .pipe(take(1))
+          .toPromise()
+          .then((res) => this.posts.push(...res));
       })
       .finally(() => (this.loading = false));
   }
@@ -65,24 +66,7 @@ export class HomeComponent implements OnInit {
   }
 
   addSearch() {
-    console.log('add');
     this.requestOptions.page++;
     this.search();
   }
-
-  //   if (
-  //     !this.maxPage ||
-  //     (this.maxPage > this.requestOptions.page && !this.loading)
-  //   ) {
-  //     this.requestOptions.page++;
-  //     const searchOptions = {
-  //       ...this.requestOptions,
-  //     };
-  //     this.index.search(this.searchQuery, searchOptions).then((result) => {
-  //       this.maxPage = result.nbPages;
-  //       this.items.push(...result.hits);
-  //       this.loading = false;
-  //     });
-  //   }
-  // }
 }

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -16,7 +16,7 @@ export class HomeComponent implements OnInit {
   index: SearchIndex = this.searchService.index.posts;
   searchControl: FormControl = new FormControl('');
   page: 0;
-  posts: PostWithUser[] = [];
+  posts: PostWithUser[];
   maxPage = 5;
   loading: boolean;
   requestOptions: any = {};
@@ -29,6 +29,7 @@ export class HomeComponent implements OnInit {
     public uiService: UiService
   ) {
     this.route.queryParamMap.subscribe((param) => {
+      this.posts = [];
       this.searchQuery = param.get('searchQuery') || '';
       this.requestOptions = {
         page: 0,

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -4,6 +4,8 @@ import { SearchIndex } from 'algoliasearch/lite';
 import { FormControl } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 import { UiService } from 'src/app/services/ui.service';
+import { take } from 'rxjs/operators';
+import { PostWithUser } from 'src/app/interfaces/post';
 
 @Component({
   selector: 'app-home',
@@ -14,8 +16,8 @@ export class HomeComponent implements OnInit {
   index: SearchIndex = this.searchService.index.posts;
   searchControl: FormControl = new FormControl('');
   page: 0;
-  items = [];
-  maxPage: number;
+  posts: PostWithUser[] = [];
+  maxPage: number = 5;
   loading: boolean;
   requestOptions: any = {};
   searchQuery: string;
@@ -39,15 +41,18 @@ export class HomeComponent implements OnInit {
   ngOnInit() {}
 
   search() {
-    this.items = new Array();
+    this.loading = true;
     const searchOptions = {
       ...this.requestOptions,
     };
-    this.index.search(this.searchQuery, searchOptions).then((result) => {
-      this.maxPage = result.nbPages;
-      this.items.push(...result.hits);
-      this.loading = false;
-    });
+    this.searchService
+      .getPostWithUser(this.searchQuery, searchOptions)
+      .then(async (result) => {
+        const items = await result.pipe(take(1)).toPromise();
+
+        this.posts.push(...items);
+      })
+      .finally(() => (this.loading = false));
   }
 
   routeSearch(searchQuery: string) {
@@ -60,19 +65,24 @@ export class HomeComponent implements OnInit {
   }
 
   addSearch() {
-    if (
-      !this.maxPage ||
-      (this.maxPage > this.requestOptions.page && !this.loading)
-    ) {
-      this.requestOptions.page++;
-      const searchOptions = {
-        ...this.requestOptions,
-      };
-      this.index.search(this.searchQuery, searchOptions).then((result) => {
-        this.maxPage = result.nbPages;
-        this.items.push(...result.hits);
-        this.loading = false;
-      });
-    }
+    console.log('add');
+    this.requestOptions.page++;
+    this.search();
   }
+
+  //   if (
+  //     !this.maxPage ||
+  //     (this.maxPage > this.requestOptions.page && !this.loading)
+  //   ) {
+  //     this.requestOptions.page++;
+  //     const searchOptions = {
+  //       ...this.requestOptions,
+  //     };
+  //     this.index.search(this.searchQuery, searchOptions).then((result) => {
+  //       this.maxPage = result.nbPages;
+  //       this.items.push(...result.hits);
+  //       this.loading = false;
+  //     });
+  //   }
+  // }
 }

--- a/src/app/interfaces/post.ts
+++ b/src/app/interfaces/post.ts
@@ -1,4 +1,5 @@
 import { firestore } from 'firebase';
+import { User } from './user';
 
 export interface Post {
   id: string;
@@ -8,4 +9,8 @@ export interface Post {
   content: string;
   public: boolean;
   createdAt: firestore.Timestamp;
+}
+
+export interface PostWithUser extends Post {
+  user: User;
 }

--- a/src/app/interfaces/user.ts
+++ b/src/app/interfaces/user.ts
@@ -1,4 +1,5 @@
 export interface User {
+  uid: string;
   name: string;
   avaterURL: string;
   email: string;

--- a/src/app/login/login/login.component.ts
+++ b/src/app/login/login/login.component.ts
@@ -13,7 +13,7 @@ export class LoginComponent implements OnInit {
     password: ['', [Validators.required, Validators.minLength(6)]],
   });
 
-  user$ = this.authService.afUser$;
+  user$ = this.authService.user$;
 
   constructor(private fb: FormBuilder, private authService: AuthService) {}
 

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -11,12 +11,12 @@ import { AngularFirestore } from '@angular/fire/firestore';
   providedIn: 'root',
 })
 export class AuthService {
-  // afUser$: Observable<User> = this.afAuth.user; // 後で消去
   userId: string;
 
-  afUser$: Observable<User> = this.afAuth.authState.pipe(
+  user$: Observable<User> = this.afAuth.authState.pipe(
     switchMap((afUser) => {
       if (afUser) {
+        this.userId = afUser.uid;
         return this.db.doc<User>(`users/${afUser.uid}`).valueChanges();
       } else {
         return of(null);
@@ -29,11 +29,7 @@ export class AuthService {
     private afAuth: AngularFireAuth,
     private router: Router,
     private snackBar: MatSnackBar
-  ) {
-    this.afUser$.subscribe((user) => {
-      this.userId = user && user.uid;
-    });
-  }
+  ) {}
 
   googleLogin() {
     const provider = new auth.GoogleAuthProvider();

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -2,6 +2,12 @@ import { environment } from 'src/environments/environment';
 import { Injectable } from '@angular/core';
 import algoliasearch from 'algoliasearch/lite';
 import { FormControl } from '@angular/forms';
+import { Post, PostWithUser } from '../interfaces/post';
+import { UserService } from './user.service';
+import { Observable, of } from 'rxjs';
+import { User } from '../interfaces/user';
+import { combineLatest } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 const searchClient = algoliasearch(
   environment.algolia.appId,
@@ -18,5 +24,39 @@ export class SearchService {
     posts: searchClient.initIndex('posts'),
   };
 
-  constructor() {}
+  constructor(private userService: UserService) {}
+
+  async getPostWithUser(
+    searchQuery,
+    searchoptions
+  ): Promise<Observable<PostWithUser[]>> {
+    const result = await this.index.posts.search(searchQuery, searchoptions);
+    console.log(result);
+    const posts = result.hits as any[];
+    const maxPage: number = result.nbPages;
+    console.log(posts);
+    if (posts.length) {
+      const uids: string[] = posts.map((item: Post) => item.userId);
+      const uniquedUserIds = Array.from(new Set(uids));
+
+      const userObservables$: Observable<User>[] = uniquedUserIds.map((uid) =>
+        this.userService.getUserByUid(uid)
+      );
+
+      const users$: Observable<User[]> = combineLatest(userObservables$);
+
+      return combineLatest([of(posts), users$]).pipe(
+        map(([items, users]) => {
+          return items.map((item) => {
+            return {
+              ...item,
+              user: users.find((user) => item.userId === user.uid),
+            };
+          });
+        })
+      );
+    } else {
+      return of([]);
+    }
+  }
 }

--- a/src/app/services/user.service.spec.ts
+++ b/src/app/services/user.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { UserService } from './user.service';
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(UserService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { AngularFirestore } from '@angular/fire/firestore';
+import { User } from '../interfaces/user';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class UserService {
+  constructor(private db: AngularFirestore) {}
+  getUserByUid(uid: string): Observable<User> {
+    return this.db.doc<User>(`users/${uid}`).valueChanges();
+  }
+}


### PR DESCRIPTION
カードにユーザー情報を表示させる処理を実装しました。
ご確認お願いいたします。

## 作業内容
- user.serviceの作成（firestoreからユーザー情報を取得）
- auth.serviceのafUser$をuser$に命名変更
- カードスタイル調整
- search.serviceでユーザー情報と投稿情報を混ぜる処理の実装
- home.component.tsでsearch.serviceからの情報を受け取る処理の実装・リファクタリング
## image
![image](https://user-images.githubusercontent.com/60844124/87369383-5727be00-c5bb-11ea-82f2-f066b6a9d615.png)


## 
fix #108 