### PR TITLE
ソート機能の実装・非公開を非表示

### DIFF
--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -43,6 +43,7 @@ export class HomeComponent implements OnInit {
         hitsPerPage: 6,
       };
       this.categoriFilter = (param.get('categories') || '').split(',');
+      this.sort = param.get('sort') || 'posts';
       this.search();
     });
   }
@@ -62,7 +63,7 @@ export class HomeComponent implements OnInit {
       setTimeout(
         () => {
           this.searchService
-            .getPostWithUser(this.searchQuery, searchOptions)
+            .getPostWithUser(this.searchQuery, searchOptions, this.sort)
             .then((result) => {
               result
                 .pipe(take(1))

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -58,7 +58,7 @@ export class HomeComponent implements OnInit {
       );
       const searchOptions = {
         ...this.requestOptions,
-        facetFilters: this.categoriFilter,
+        facetFilters: [this.categoriFilter, 'public:true'],
       };
       setTimeout(
         () => {

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -29,8 +29,9 @@ export class SearchService {
   async getPostWithUser(
     searchQuery,
     searchoptions,
-    sortKey: string = 'posts'
+    sortKey: string
   ): Promise<Observable<PostWithUser[]>> {
+    console.log(sortKey);
     const result = await this.index[sortKey].search(searchQuery, searchoptions);
     const posts = result.hits as any[];
     const maxPage: number = result.nbPages;

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -31,7 +31,6 @@ export class SearchService {
     searchoptions,
     sortKey: string
   ): Promise<Observable<PostWithUser[]>> {
-    console.log(sortKey);
     const result = await this.index[sortKey].search(searchQuery, searchoptions);
     const posts = result.hits as any[];
     const maxPage: number = result.nbPages;

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -18,19 +18,20 @@ const searchClient = algoliasearch(
   providedIn: 'root',
 })
 export class SearchService {
-  // インデックスリスト
   index = {
-    // アイテムインデックス
     posts: searchClient.initIndex('posts'),
+    Latest: searchClient.initIndex('Latest'),
+    Oldest: searchClient.initIndex('Oldest'),
   };
 
   constructor(private userService: UserService) {}
 
   async getPostWithUser(
     searchQuery,
-    searchoptions
+    searchoptions,
+    sortKey: string = 'posts'
   ): Promise<Observable<PostWithUser[]>> {
-    const result = await this.index.posts.search(searchQuery, searchoptions);
+    const result = await this.index[sortKey].search(searchQuery, searchoptions);
     const posts = result.hits as any[];
     const maxPage: number = result.nbPages;
     if (posts.length) {

--- a/src/app/shared/filter/filter.component.html
+++ b/src/app/shared/filter/filter.component.html
@@ -1,13 +1,10 @@
 <button (click)="toggle()" mat-icon-button>
   <mat-icon>filter_list</mat-icon>
 </button>
-<div *ngIf="visible">
+<div *ngIf="visible" class="grid">
   <div class="filter">
-    <label id="filter__title">カテゴリー</label>
-    <mat-radio-group
-      aria-labelledby="filter__title"
-      (change)="buildQueryParameterByCategories($event)"
-    >
+    <p class="filter__title">カテゴリー</p>
+    <mat-radio-group (change)="buildQueryParameterByCategories($event)">
       <mat-radio-button
         class="radio-button"
         *ngFor="let tag of categories"
@@ -16,5 +13,16 @@
         {{ tag.value }}
       </mat-radio-button>
     </mat-radio-group>
+  </div>
+
+  <div class="filter">
+    <p class="filter__title">並び替え</p>
+    <mat-selection-list
+      (selectionChange)="buildQueryParameterBySort($event)"
+      [multiple]="false"
+    >
+      <mat-list-option value="Latest"> 最新順 </mat-list-option>
+      <mat-list-option value="Oldest"> 古い順 </mat-list-option>
+    </mat-selection-list>
   </div>
 </div>

--- a/src/app/shared/filter/filter.component.scss
+++ b/src/app/shared/filter/filter.component.scss
@@ -14,3 +14,8 @@
     margin: 15px 0;
   }
 }
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+}

--- a/src/app/shared/filter/filter.component.ts
+++ b/src/app/shared/filter/filter.component.ts
@@ -3,6 +3,7 @@ import { SearchService } from 'src/app/services/search.service';
 import { FormControl } from '@angular/forms';
 import { Router } from '@angular/router';
 import { MatRadioChange } from '@angular/material/radio';
+import { MatSelectionListChange, MatListOption } from '@angular/material/list';
 
 @Component({
   selector: 'app-filter',
@@ -43,6 +44,16 @@ export class FilterComponent implements OnInit {
     this.router.navigate([''], {
       queryParams: {
         categories: categoriesFilter,
+      },
+      queryParamsHandling: 'merge',
+    });
+  }
+
+  buildQueryParameterBySort(event: MatSelectionListChange) {
+    const key: MatListOption = event.source.selectedOptions.selected[0].value;
+    this.router.navigate([''], {
+      queryParams: {
+        sort: key,
       },
       queryParamsHandling: 'merge',
     });


### PR DESCRIPTION
ソート機能・非公開に設定した投稿を非表示にする処理を実装しました。
スタイル調整は別にissueをたてて対応します。
ご確認お願いいたします。
## 作業内容
- 日付順ソートの実装
- 非公開設定の反映

## image
![Image](https://i.gyazo.com/848cdf2b1201977d310b44037c1df788.gif)
下記は一番新しい投稿、publicがfalseのため上記のように最新順にしても表示されない
![image](https://user-images.githubusercontent.com/60844124/87747874-69aa2d80-c82f-11ea-8a97-83bf64ebfabd.png)


##
fix #61 
fix #58 