### PR TITLE
無限スクロール修正

### DIFF
--- a/src/app/home/home/home.component.html
+++ b/src/app/home/home/home.component.html
@@ -68,7 +68,7 @@
   </div>
   <div
     infiniteScroll
-    [infiniteScrollDistance]="2"
+    [infiniteScrollDistance]="0.1"
     [infiniteScrollThrottle]="20"
     [infiniteScrollContainer]="uiService.scrollWrapperElement"
     (scrolled)="addSearch()"

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -45,37 +45,36 @@ export class HomeComponent implements OnInit {
       this.categoriFilter = (param.get('categories') || '').split(',');
       this.sort = param.get('sort') || 'posts';
       this.search();
+      this.isInit = false;
     });
   }
 
   ngOnInit() {}
 
   search() {
-    if (!this.loading) {
-      this.loading = true;
-      this.categoriFilter = this.categoriFilter.map(
-        (category) => `category:${category}`
-      );
-      const searchOptions = {
-        ...this.requestOptions,
-        facetFilters: [this.categoriFilter, 'public:true'],
-      };
-      setTimeout(
-        () => {
-          this.searchService
-            .getPostWithUser(this.searchQuery, searchOptions, this.sort)
-            .then((result) => {
-              result
-                .pipe(take(1))
-                .toPromise()
-                .then((res) => this.posts.push(...res));
-              this.isInit = false;
-            })
-            .finally(() => (this.loading = false));
-        },
-        this.isInit ? 0 : 1000
-      );
-    }
+    this.loading = true;
+    this.categoriFilter = this.categoriFilter.map(
+      (category) => `category:${category}`
+    );
+    const searchOptions = {
+      ...this.requestOptions,
+      facetFilters: [this.categoriFilter, 'public:true'],
+    };
+    console.log(searchOptions);
+    setTimeout(() => {
+      this.searchService
+        .getPostWithUser(
+          this.searchQuery,
+          searchOptions,
+          this.sort,
+          this.isInit
+        )
+        .then(async (result) => {
+          const items = await result.pipe(take(1)).toPromise();
+          this.posts.push(...items);
+        })
+        .finally(() => (this.loading = false));
+    });
   }
 
   routeSearch(searchQuery: string) {
@@ -89,6 +88,7 @@ export class HomeComponent implements OnInit {
 
   addSearch() {
     this.requestOptions.page++;
+    console.log(this.requestOptions.page);
     this.search();
   }
 }

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -60,7 +60,6 @@ export class HomeComponent implements OnInit {
       ...this.requestOptions,
       facetFilters: [this.categoriFilter, 'public:true'],
     };
-    console.log(searchOptions);
     setTimeout(() => {
       this.searchService
         .getPostWithUser(
@@ -88,7 +87,6 @@ export class HomeComponent implements OnInit {
 
   addSearch() {
     this.requestOptions.page++;
-    console.log(this.requestOptions.page);
     this.search();
   }
 }

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -7,7 +7,7 @@ import { UserService } from './user.service';
 import { Observable, of } from 'rxjs';
 import { User } from '../interfaces/user';
 import { combineLatest } from 'rxjs';
-import { map, filter } from 'rxjs/operators';
+import { map, filter, delay } from 'rxjs/operators';
 
 const searchClient = algoliasearch(
   environment.algolia.appId,
@@ -29,7 +29,8 @@ export class SearchService {
   async getPostWithUser(
     searchQuery,
     searchoptions,
-    sortKey: string
+    sortKey: string,
+    isInit: boolean
   ): Promise<Observable<PostWithUser[]>> {
     const result = await this.index[sortKey].search(searchQuery, searchoptions);
     const posts = result.hits as any[];
@@ -51,7 +52,8 @@ export class SearchService {
               user: users.find((user) => item.userId === user.uid),
             };
           });
-        })
+        }),
+        delay(isInit ? 0 : 1000)
       );
     } else {
       return of([]);


### PR DESCRIPTION
偶数ページが表示されていなかったバグを修正しました。
```ts
search() {
    if (!this.loading) {
```
search()からこのif文を外したら正常に動きました。２ページを読み込むときにloadingがtrueになっていて飛ばされてしまったのでしょうか？
ご確認お願いいたします。
## image
- 下の画像のコンソールに表示されている内容
```ts
search() {
// ~~~
const searchOptions = {
...this.requestOptions,
facetFilters: [this.categoriFilter, 'public:true'],
};
console.log(searchOptions);
```
```ts
addSearch() {
this.requestOptions.page++;
console.log(this.requestOptions.page);
this.search();
}
```
- if (!this.loading)で囲んでいるとき
[![Image from Gyazo](https://i.gyazo.com/d860eaa14f041d3f0dd5ead3337ec219.gif)](https://gyazo.com/d860eaa14f041d3f0dd5ead3337ec219)
- if (!this.loading)を外した状態
[![Image from Gyazo](https://i.gyazo.com/214c4e12a3ed087c933ee5a6e64193a3.gif)](https://gyazo.com/214c4e12a3ed087c933ee5a6e64193a3)

Fixes #127
