### PR TITLE
記事詳細ページ作成

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -50,6 +50,13 @@ const routes: Routes = [
     loadChildren: () =>
       import('./shared/shared.module').then((m) => m.SharedModule),
   },
+  {
+    path: 'post-detail',
+    loadChildren: () =>
+      import('./post-detail/post-detail.module').then(
+        (m) => m.PostDetailModule
+      ),
+  },
 
   {
     path: '**',

--- a/src/app/interfaces/post.ts
+++ b/src/app/interfaces/post.ts
@@ -9,7 +9,7 @@ export interface Post {
   content: string;
   public: boolean;
   likeCount: number;
-  createdAt: firestore.Timestamp;
+  createdAt: number;
   currentPosition: google.maps.LatLngLiteral;
 }
 

--- a/src/app/post-detail/post-detail-routing.module.ts
+++ b/src/app/post-detail/post-detail-routing.module.ts
@@ -4,10 +4,6 @@ import { PostDetailComponent } from './post-detail/post-detail.component';
 
 const routes: Routes = [
   {
-    path: '',
-    component: PostDetailComponent,
-  },
-  {
     path: ':id',
     component: PostDetailComponent,
   },

--- a/src/app/post-detail/post-detail-routing.module.ts
+++ b/src/app/post-detail/post-detail-routing.module.ts
@@ -1,0 +1,20 @@
+import { NgModule, Component } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { PostDetailComponent } from './post-detail/post-detail.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: PostDetailComponent,
+  },
+  {
+    path: ':id',
+    component: PostDetailComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class PostDetailRoutingModule {}

--- a/src/app/post-detail/post-detail.module.ts
+++ b/src/app/post-detail/post-detail.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { PostDetailRoutingModule } from './post-detail-routing.module';
+import { PostDetailComponent } from './post-detail/post-detail.component';
+import { SharedModule } from '../shared/shared.module';
+
+@NgModule({
+  declarations: [PostDetailComponent],
+  imports: [CommonModule, PostDetailRoutingModule, SharedModule],
+})
+export class PostDetailModule {}

--- a/src/app/post-detail/post-detail/post-detail.component.html
+++ b/src/app/post-detail/post-detail/post-detail.component.html
@@ -1,0 +1,4 @@
+<div class="container">
+  <app-google-map-small></app-google-map-small>
+  <app-post-card *ngIf="post" [post]="post"></app-post-card>
+</div>

--- a/src/app/post-detail/post-detail/post-detail.component.spec.ts
+++ b/src/app/post-detail/post-detail/post-detail.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PostDetailComponent } from './post-detail.component';
+
+describe('PostDetailComponent', () => {
+  let component: PostDetailComponent;
+  let fixture: ComponentFixture<PostDetailComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [PostDetailComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PostDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/post-detail/post-detail/post-detail.component.ts
+++ b/src/app/post-detail/post-detail/post-detail.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { PostService } from 'src/app/services/post.service';
+import { Post, PostWithUser } from 'src/app/interfaces/post';
+import { Observable } from 'rxjs';
+import { async } from '@angular/core/testing';
+import { take } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-post-detail',
+  templateUrl: './post-detail.component.html',
+  styleUrls: ['./post-detail.component.scss'],
+})
+export class PostDetailComponent implements OnInit {
+  post$: Promise<Observable<Post>>;
+  post: PostWithUser;
+
+  constructor(private route: ActivatedRoute, private postService: PostService) {
+    route.paramMap.subscribe((params) => {
+      postService.getPostWithUserById(params.get('id')).then(async (result) => {
+        this.post = await result.pipe(take(1)).toPromise();
+      });
+    });
+    setTimeout(() => {
+      console.log(this.post);
+    }, 1000);
+  }
+
+  ngOnInit(): void {}
+}

--- a/src/app/post-detail/post-detail/post-detail.component.ts
+++ b/src/app/post-detail/post-detail/post-detail.component.ts
@@ -21,9 +21,6 @@ export class PostDetailComponent implements OnInit {
         this.post = await result.pipe(take(1)).toPromise();
       });
     });
-    setTimeout(() => {
-      console.log(this.post);
-    }, 1000);
   }
 
   ngOnInit(): void {}

--- a/src/app/services/post.service.ts
+++ b/src/app/services/post.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Input } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/firestore';
-import { Post } from '../interfaces/post';
-import { map, switchMap, first } from 'rxjs/operators';
+import { Post, PostWithUser } from '../interfaces/post';
+import { map, switchMap, first, take } from 'rxjs/operators';
 import { Observable, combineLatest } from 'rxjs';
 import { firestore } from 'firebase';
 import { AuthService } from './auth.service';
@@ -9,6 +9,7 @@ import { AngularFireStorage } from '@angular/fire/storage';
 
 import { User } from '../interfaces/user';
 import { LikedPostDocument } from '../interfaces/liked-post-document';
+import { UserService } from './user.service';
 
 @Injectable({
   providedIn: 'root',
@@ -18,7 +19,8 @@ export class PostService {
   constructor(
     private db: AngularFirestore,
     private authService: AuthService,
-    private storage: AngularFireStorage
+    private storage: AngularFireStorage,
+    private userService: UserService
   ) {}
 
   async createPost(
@@ -52,12 +54,32 @@ export class PostService {
     }
   }
 
-  getPost(): Observable<Post[]> {
-    return this.db
-      .collection<Post>('posts', (ref) => {
-        return ref.limit(2);
+  getPostById(id: string): Observable<Post> {
+    console.log(id);
+    return this.db.doc<Post>(`posts/${id}`).valueChanges();
+  }
+
+  async getPostWithUserById(id: string): Promise<Observable<PostWithUser>> {
+    const post$: Observable<Post> = this.getPostById(id);
+    const uid$ = post$.pipe(map((item: Post) => item.userId));
+    const uid = await uid$.pipe(take(1)).toPromise();
+    console.log(uid);
+    const user$: Observable<User> = this.userService.getUserByUid(uid);
+    post$.subscribe((post) => {
+      console.log(post);
+    });
+    user$.subscribe((user) => {
+      console.log(user);
+    });
+
+    return combineLatest([post$, user$]).pipe(
+      map(([item, user]) => {
+        return {
+          ...item,
+          user,
+        };
       })
-      .valueChanges();
+    );
   }
 
   getPosts(): Observable<Post[]> {

--- a/src/app/services/post.service.ts
+++ b/src/app/services/post.service.ts
@@ -55,7 +55,6 @@ export class PostService {
   }
 
   getPostById(id: string): Observable<Post> {
-    console.log(id);
     return this.db.doc<Post>(`posts/${id}`).valueChanges();
   }
 
@@ -63,14 +62,7 @@ export class PostService {
     const post$: Observable<Post> = this.getPostById(id);
     const uid$ = post$.pipe(map((item: Post) => item.userId));
     const uid = await uid$.pipe(take(1)).toPromise();
-    console.log(uid);
     const user$: Observable<User> = this.userService.getUserByUid(uid);
-    post$.subscribe((post) => {
-      console.log(post);
-    });
-    user$.subscribe((user) => {
-      console.log(user);
-    });
 
     return combineLatest([post$, user$]).pipe(
       map(([item, user]) => {

--- a/src/app/services/post.service.ts
+++ b/src/app/services/post.service.ts
@@ -35,7 +35,7 @@ export class PostService {
       id,
       imageURL,
       currentPosition,
-      createdAt: firestore.Timestamp.now(),
+      createdAt: Date.now(),
       userId: this.authService.userId,
       likeCount: 0,
       ...post,

--- a/src/app/shared/post-card/post-card.component.html
+++ b/src/app/shared/post-card/post-card.component.html
@@ -21,7 +21,7 @@
       <mat-card-content class="card__body">
         <p class="card__content">{{ post.content }}</p>
         <p class="card__date">
-          {{ createdDate }}
+          {{ post.createdAt | date: 'yyyy/MM/dd HH:mm' }}
         </p>
       </mat-card-content>
       <div class="card__actions">

--- a/src/app/shared/post-card/post-card.component.html
+++ b/src/app/shared/post-card/post-card.component.html
@@ -1,49 +1,51 @@
 <div class="timeLine">
   <mat-card class="card">
-    <mat-card-header>
-      <div
-        mat-card-avatar
-        [style.background-image]="'url(' + post.user.avaterURL + ')'"
-        class="card__avatar"
-      ></div>
-      <mat-card-title>{{ post.user.name }}</mat-card-title>
-      <mat-card-subtitle>{{ post.category }}</mat-card-subtitle>
-    </mat-card-header>
-    <a href="{{ post.imageURL }}">
-      <div
-        *ngIf="post.imageURL"
-        [style.background-image]="'url(' + post.imageURL + ')'"
-        class="card__image"
-        alt="image"
-      ></div>
-    </a>
-    <mat-card-content class="card__body">
-      <p class="card__content">{{ post.content }}</p>
-      <p class="card__date">
-        {{ post.createdAt | date: 'yyyy/MM/dd HH:mm' }}
-      </p>
-    </mat-card-content>
-    <div class="card__actions">
-      <button
-        *ngIf="isLiked; else unLiked"
-        (click)="unLikePost(post.id)"
-        class="card__like-btn"
-        mat-icon-button
-        color="warn"
-      >
-        <mat-icon>favorite</mat-icon>
-        <span>{{ post.likeCount }}</span>
-      </button>
-      <ng-template #unLiked>
+    <a href="" class="card__link" routerLink="/post-detail/{{ post.id }}">
+      <mat-card-header>
+        <div
+          mat-card-avatar
+          [style.background-image]="'url(' + post.user.avaterURL + ')'"
+          class="card__avatar"
+        ></div>
+        <mat-card-title>{{ post.user.name }}</mat-card-title>
+        <mat-card-subtitle>{{ post.category }}</mat-card-subtitle>
+      </mat-card-header>
+      <a href="{{ post.imageURL }}">
+        <div
+          *ngIf="post.imageURL"
+          [style.background-image]="'url(' + post.imageURL + ')'"
+          class="card__image"
+          alt="image"
+        ></div>
+      </a>
+      <mat-card-content class="card__body">
+        <p class="card__content">{{ post.content }}</p>
+        <p class="card__date">
+          {{ createdDate }}
+        </p>
+      </mat-card-content>
+      <div class="card__actions">
         <button
-          [disabled]="isProcessing"
-          (click)="likePost(post)"
+          *ngIf="isLiked; else unLiked"
+          (click)="unLikePost(post.id)"
+          class="card__like-btn"
           mat-icon-button
+          color="warn"
         >
-          <mat-icon>favorite_border</mat-icon>
+          <mat-icon>favorite</mat-icon>
           <span>{{ post.likeCount }}</span>
         </button>
-      </ng-template>
-    </div>
+        <ng-template #unLiked>
+          <button
+            [disabled]="isProcessing"
+            (click)="likePost(post)"
+            mat-icon-button
+          >
+            <mat-icon>favorite_border</mat-icon>
+            <span>{{ post.likeCount }}</span>
+          </button>
+        </ng-template>
+      </div>
+    </a>
   </mat-card>
 </div>

--- a/src/app/shared/post-card/post-card.component.scss
+++ b/src/app/shared/post-card/post-card.component.scss
@@ -1,6 +1,10 @@
 .card {
   border-radius: 4px;
   box-shadow: 0 0 3px #ccc;
+  &__link {
+    text-decoration: none;
+    color: inherit;
+  }
   &__image {
     width: 100%;
     max-width: 100%;

--- a/src/app/shared/post-card/post-card.component.ts
+++ b/src/app/shared/post-card/post-card.component.ts
@@ -5,18 +5,23 @@ import { PostService } from 'src/app/services/post.service';
 import { User } from 'src/app/interfaces/user';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
+import { DatePipe } from '@angular/common';
 
 @Component({
   selector: 'app-post-card',
   templateUrl: './post-card.component.html',
   styleUrls: ['./post-card.component.scss'],
+  providers: [DatePipe],
 })
 export class PostCardComponent implements OnInit {
   @Input() post: PostWithUser;
 
+  createdDate: string;
+
   constructor(
     private userService: UserService,
-    private postService: PostService
+    private postService: PostService,
+    private datePipe: DatePipe
   ) {}
 
   user$: Observable<User> = this.userService.user$.pipe(
@@ -30,6 +35,17 @@ export class PostCardComponent implements OnInit {
 
   ngOnInit(): void {
     this.user$.subscribe();
+    if (typeof this.post.createdAt === 'number') {
+      this.createdDate = this.datePipe.transform(
+        this.post.createdAt,
+        'yyyy/MM/dd HH:mm'
+      );
+    } else {
+      this.createdDate = this.datePipe.transform(
+        this.post.createdAt.toDate(),
+        'yyyy/MM/dd HH:mm'
+      );
+    }
   }
   async likePost(post: PostWithUser): Promise<void[]> {
     this.isProcessing = true;

--- a/src/app/shared/post-card/post-card.component.ts
+++ b/src/app/shared/post-card/post-card.component.ts
@@ -35,17 +35,6 @@ export class PostCardComponent implements OnInit {
 
   ngOnInit(): void {
     this.user$.subscribe();
-    if (typeof this.post.createdAt === 'number') {
-      this.createdDate = this.datePipe.transform(
-        this.post.createdAt,
-        'yyyy/MM/dd HH:mm'
-      );
-    } else {
-      this.createdDate = this.datePipe.transform(
-        this.post.createdAt.toDate(),
-        'yyyy/MM/dd HH:mm'
-      );
-    }
   }
   async likePost(post: PostWithUser): Promise<void[]> {
     this.isProcessing = true;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -13,6 +13,7 @@ body {
   padding: 0 24px;
   margin: 76px auto;
   box-sizing: border-box;
+  text-align: center;
 }
 img {
   max-width: 100%;


### PR DESCRIPTION
fix #71 

記事を単体で取ってくるページを作成しました。
ご確認お願い致します。

## 作業内容
- post-detail.Module作成(https://github.com/camp-team/yama-portal-2/commit/4bcd700b5328fbe07410a4711132450dce08a7ce)
- 記事idから記事を取得する関数を作成(https://github.com/camp-team/yama-portal-2/commit/869ca1972ab34f077d15613a9cc4dc6d00d82a58)
- firestore.timestamp型への対応(https://github.com/camp-team/yama-portal-2/commit/be35b808d6589373fdc1dcf143ef9858209f2125)
## image
[![Image from Gyazo](https://i.gyazo.com/a1a9b567c6887dcee8f21b639a236a68.gif)](https://gyazo.com/a1a9b567c6887dcee8f21b639a236a68)