### PR TITLE
googleMap/InfoWindowの調整

### DIFF
--- a/src/app/post-detail/post-detail/post-detail.component.html
+++ b/src/app/post-detail/post-detail/post-detail.component.html
@@ -1,4 +1,4 @@
-<div class="container">
-  <app-google-map-small></app-google-map-small>
-  <app-post-card *ngIf="post" [post]="post"></app-post-card>
+<div class="container" *ngIf="post">
+  <app-google-map-small [post]="post"></app-google-map-small>
+  <app-post-card [post]="post"></app-post-card>
 </div>

--- a/src/app/shared/google-map-small/google-map-small.component.html
+++ b/src/app/shared/google-map-small/google-map-small.component.html
@@ -21,9 +21,17 @@
     [options]="changeMarkerIcons(posts.category)"
     (mapClick)="openInfoWindow(marker, window)"
   >
-    <map-info-window #window="mapInfoWindow">
-      <div>{{ posts.category }}</div>
-      <div>{{ posts.content }}</div>
+    <map-info-window class="info__container" #window="mapInfoWindow">
+      <a href="" class="info__link" routerLink="/post-detail/{{ posts.id }}">
+        <div class="info__content">{{ posts.content }}</div>
+        <ng-container class="info__image" *ngIf="posts.imageURL">
+          <div
+            [style.background-image]="'url(' + posts.imageURL + ')'"
+            class="info__image"
+            alt="image"
+          ></div>
+        </ng-container>
+      </a>
     </map-info-window>
   </map-marker>
 </google-map>

--- a/src/app/shared/google-map-small/google-map-small.component.scss
+++ b/src/app/shared/google-map-small/google-map-small.component.scss
@@ -9,3 +9,26 @@
     z-index: 100;
   }
 }
+
+.info {
+  &__container {
+    font-family: 'Arial', sans-serif;
+    display: block;
+    width: 200px;
+    position: relative;
+    background: white;
+    opacity: 0.9;
+  }
+  &__link {
+    text-decoration: none;
+    color: inherit;
+  }
+  &__image {
+    width: 100%;
+    max-width: 100%;
+    height: 200px;
+    background: white center/cover;
+    display: block;
+    text-align: center;
+  }
+}

--- a/src/app/shared/google-map-small/google-map-small.component.ts
+++ b/src/app/shared/google-map-small/google-map-small.component.ts
@@ -1,8 +1,14 @@
-import { Component, OnInit, ViewChild, AfterViewInit } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  ViewChild,
+  AfterViewInit,
+  Input,
+} from '@angular/core';
 import { MapMarker, GoogleMap, MapInfoWindow } from '@angular/google-maps';
 import { PostService } from 'src/app/services/post.service';
 import { Observable } from 'rxjs';
-import { Post } from 'src/app/interfaces/post';
+import { Post, PostWithUser } from 'src/app/interfaces/post';
 
 @Component({
   selector: 'app-google-map-small',
@@ -11,6 +17,7 @@ import { Post } from 'src/app/interfaces/post';
 })
 export class GoogleMapSmallComponent implements OnInit, AfterViewInit {
   @ViewChild(GoogleMap, { static: false }) map: google.maps.Map;
+  @Input() post: PostWithUser;
 
   public zoom = 14;
   public center: google.maps.LatLngLiteral = {
@@ -38,6 +45,9 @@ export class GoogleMapSmallComponent implements OnInit, AfterViewInit {
           lng: position.coords.longitude,
         };
       });
+    }
+    if (!!this.post) {
+      this.center = this.post.currentPosition;
     }
   }
 


### PR DESCRIPTION
fix #135 
InfoWindowの調整を行いました。
ご確認お願い致します。

## 作業内容
- InfoWindowに画像を表示
- 記事詳細画面へのリンク
- 記事詳細画面に遷移した時に表示された記事のピンがマップの中央に表示されるように変更

## Image
InfoWindowの中をクリックすると記事詳細に遷移
[![Image from Gyazo](https://i.gyazo.com/8982daf85a710c65d55863c00463cf61.gif)](https://gyazo.com/8982daf85a710c65d55863c00463cf61)
記事詳細画面に遷移した時に該当の記事のピンがマップの中央になる
[![Image from Gyazo](https://i.gyazo.com/14d34dbf59f774af2cf70dadaccabc3b.gif)](https://gyazo.com/14d34dbf59f774af2cf70dadaccabc3b)
