### PR TITLE
GithubActionsエラーへの対応

### DIFF
--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -40,3 +40,4 @@ jobs:
           args: deploy
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          PROJECT_ID: prod


### PR DESCRIPTION
GithubActionsで下記のエラーが出ていたのでymlにPROJECT_ID: prodを追加しました。
ご確認お願い致します
```
Error: No project active, but project aliases are available.

Run firebase use <alias> with one of these options:
```
![image](https://user-images.githubusercontent.com/60844124/93181050-f0698100-f772-11ea-8e4d-6bd7a0a26bf9.png)
