### PR TITLE
記事編集・削除を実装

### DIFF
--- a/src/app/billing/billing/billing.component.ts
+++ b/src/app/billing/billing/billing.component.ts
@@ -17,8 +17,8 @@ import { CustomerService } from 'src/app/services/customer.service';
   styleUrls: ['./billing.component.scss'],
 })
 export class BillingComponent implements OnInit, OnDestroy {
-  public paymentMethod: Stripe.PaymentMethod;
-  public paymentMethods: Stripe.PaymentMethod[];
+  paymentMethod: Stripe.PaymentMethod;
+  paymentMethods: Stripe.PaymentMethod[];
 
   private subscriptions: Subscription = new Subscription();
   loading = true;

--- a/src/app/form/form-routing.module.ts
+++ b/src/app/form/form-routing.module.ts
@@ -9,6 +9,12 @@ const routes: Routes = [
     pathMatch: 'full',
     component: FormComponent,
     canDeactivate: [FormGuard],
+    children: [
+      {
+        path: ':id',
+        component: FormComponent,
+      },
+    ],
   },
 ];
 

--- a/src/app/form/form.module.ts
+++ b/src/app/form/form.module.ts
@@ -13,6 +13,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatIconModule } from '@angular/material/icon';
 import { ImageCropperModule } from 'ngx-image-cropper';
 import { SharedModule } from '../shared/shared.module';
+import { MAT_SNACK_BAR_DEFAULT_OPTIONS } from '@angular/material/snack-bar';
 
 @NgModule({
   declarations: [FormComponent],
@@ -30,6 +31,9 @@ import { SharedModule } from '../shared/shared.module';
     MatIconModule,
     ImageCropperModule,
     SharedModule,
+  ],
+  providers: [
+    { provide: MAT_SNACK_BAR_DEFAULT_OPTIONS, useValue: { duration: 3000 } },
   ],
 })
 export class FormModule {}

--- a/src/app/form/form/form.component.html
+++ b/src/app/form/form/form.component.html
@@ -42,10 +42,11 @@
       <textarea
         matTextareaAutosize
         type="text"
-        formControlName="content"
         placeholder="test"
+        formControlName="content"
         matInput
         required
+        [(ngModel)]="content"
       ></textarea>
       <mat-error *ngIf="contentControl.hasError('required')"
         >必須入力です</mat-error
@@ -75,14 +76,25 @@
     >
       写真を削除
     </button>
-
-    <button
-      mat-raised-button
-      color="primary"
-      [disabled]="form.invalid"
-      class="form__button"
-    >
-      投稿
-    </button>
+    <ng-container *ngIf="isEdit; else create">
+      <button
+        mat-raised-button
+        color="primary"
+        [disabled]="form.invalid || form.pristine"
+        class="form__button"
+      >
+        更新
+      </button>
+    </ng-container>
+    <ng-template #create>
+      <button
+        mat-raised-button
+        color="primary"
+        [disabled]="form.invalid"
+        class="form__button"
+      >
+        投稿
+      </button>
+    </ng-template>
   </form>
 </div>

--- a/src/app/form/form/form.component.ts
+++ b/src/app/form/form/form.component.ts
@@ -1,9 +1,18 @@
-import { Component, OnInit, HostListener, OnDestroy } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  HostListener,
+  OnDestroy,
+  Inject,
+} from '@angular/core';
 import { FormBuilder, Validators, FormControl } from '@angular/forms';
 import { PostService } from 'src/app/services/post.service';
 import { MatDialog } from '@angular/material/dialog';
 import { ImageUploadDialogComponent } from 'src/app/shared/dialogs/image-upload-dialog/image-upload-dialog.component';
-import { MatSnackBar } from '@angular/material/snack-bar';
+import {
+  MatSnackBar,
+  MAT_SNACK_BAR_DEFAULT_OPTIONS,
+} from '@angular/material/snack-bar';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Post } from 'src/app/interfaces/post';
 import { Subscription } from 'rxjs';
@@ -46,7 +55,8 @@ export class FormComponent implements OnInit, OnDestroy {
     private snackBar: MatSnackBar,
     private router: Router,
     private route: ActivatedRoute,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    @Inject(MAT_SNACK_BAR_DEFAULT_OPTIONS) public data: any
   ) {}
 
   ngOnInit(): void {
@@ -108,18 +118,22 @@ export class FormComponent implements OnInit, OnDestroy {
       this.postService
         .updatePost(this.form.value, this.file, this.post.id)
         .then(() => {
-          this.snackBar.open('更新しました、反映にはリロードが必要です', null, {
-            duration: 3000,
-          });
+          this.snackBar.open(
+            '更新しました、反映にはリロードが必要です',
+            null,
+            this.data
+          );
           this.router.navigateByUrl('/');
         });
     } else {
       this.postService
         .createPost(this.form.value, this.file, this.currentPosition)
         .then(() => {
-          this.snackBar.open('投稿しました、反映にはリロードが必要です', null, {
-            duration: 3000,
-          });
+          this.snackBar.open(
+            '投稿しました、反映にはリロードが必要です',
+            null,
+            this.data
+          );
           this.router.navigateByUrl('/');
         });
     }

--- a/src/app/form/form/form.component.ts
+++ b/src/app/form/form/form.component.ts
@@ -15,11 +15,11 @@ import { take } from 'rxjs/operators';
   styleUrls: ['./form.component.scss'],
 })
 export class FormComponent implements OnInit, OnDestroy {
-  public isChecked = true;
-  public isPosition = true;
-  public imageFile: string | ArrayBuffer;
-  public content = null;
-  public isEdit: boolean;
+  isChecked = true;
+  isPosition = true;
+  imageFile: string | ArrayBuffer;
+  content = null;
+  isEdit: boolean;
 
   private file: File | null = null;
   private croppedImage: string = null;

--- a/src/app/form/form/form.component.ts
+++ b/src/app/form/form/form.component.ts
@@ -63,8 +63,8 @@ export class FormComponent implements OnInit, OnDestroy {
 
   initForm() {
     this.route.queryParamMap.subscribe((map) => {
-      if (map.get('id')) {
-        const id = map.get('id');
+      const id = map.get('id');
+      if (id) {
         this.isEdit = true;
         this.subscriptions.add(
           this.postService

--- a/src/app/form/form/form.component.ts
+++ b/src/app/form/form/form.component.ts
@@ -15,7 +15,6 @@ import { take } from 'rxjs/operators';
   styleUrls: ['./form.component.scss'],
 })
 export class FormComponent implements OnInit, OnDestroy {
-  public isComplete: boolean;
   public isChecked = true;
   public isPosition = true;
   public imageFile: string | ArrayBuffer;
@@ -117,9 +116,6 @@ export class FormComponent implements OnInit, OnDestroy {
     } else {
       this.postService
         .createPost(this.form.value, this.file, this.currentPosition)
-        .then(() => {
-          this.isComplete = true;
-        })
         .then(() => {
           this.snackBar.open('投稿しました、反映にはリロードが必要です', null, {
             duration: 3000,

--- a/src/app/services/post.service.ts
+++ b/src/app/services/post.service.ts
@@ -44,6 +44,23 @@ export class PostService {
     return newValue;
   }
 
+  async updatePost(
+    post: Omit<Post, 'id' | 'createdAt' | 'userId'>,
+    file: Blob,
+    id: string
+  ) {
+    const urls = await this.uploadImage(id, file);
+    const imageURL = urls;
+    const newValue: Post = {
+      id,
+      imageURL,
+      createdAt: Date.now(),
+      userId: this.authService.userId,
+      ...post,
+    };
+    return this.db.doc<Post>(`posts/${id}`).update(newValue);
+  }
+
   async uploadImage(id: string, file: Blob): Promise<string> {
     if (file === null) {
       const urls = null;
@@ -82,10 +99,6 @@ export class PostService {
 
   deletePost(id: string): Promise<void> {
     return this.db.doc<Post>(`posts/${id}`).delete();
-  }
-
-  updatePost(post: Post) {
-    return this.db.doc<Post>(`posts/${post.id}`).update(post);
   }
 
   likePost(post: Post, userId: string): Promise<void[]> {

--- a/src/app/shared/google-map-large/google-map-large.component.ts
+++ b/src/app/shared/google-map-large/google-map-large.component.ts
@@ -19,19 +19,19 @@ import { PostService } from 'src/app/services/post.service';
 export class GoogleMapLargeComponent implements OnInit, AfterViewInit {
   @ViewChild(GoogleMap, { static: false }) map: google.maps.Map;
 
-  public zoom = 14;
-  public center: google.maps.LatLngLiteral = {
+  zoom = 14;
+  center: google.maps.LatLngLiteral = {
     lat: 34.863439,
     lng: 139.001569,
   };
-  public options: google.maps.MapOptions = {
+  options: google.maps.MapOptions = {
     disableDefaultUI: true,
   };
-  public currentPosition: google.maps.LatLngLiteral;
-  public currentPositionMarkerOption = { draggable: false };
+  currentPosition: google.maps.LatLngLiteral;
+  currentPositionMarkerOption = { draggable: false };
 
-  public posts$: Observable<Post[]> = this.postService.getPosts();
-  public markerOptions = { draggable: false };
+  posts$: Observable<Post[]> = this.postService.getPosts();
+  markerOptions = { draggable: false };
 
   constructor(private postService: PostService, private router: Router) {}
 

--- a/src/app/shared/google-map-small/google-map-small.component.ts
+++ b/src/app/shared/google-map-small/google-map-small.component.ts
@@ -20,19 +20,19 @@ export class GoogleMapSmallComponent implements OnInit, AfterViewInit {
   @ViewChild(GoogleMap, { static: false }) map: google.maps.Map;
   @Input() post: PostWithUser;
 
-  public zoom = 14;
-  public center: google.maps.LatLngLiteral = {
+  zoom = 14;
+  center: google.maps.LatLngLiteral = {
     lat: 34.863439,
     lng: 139.001569,
   };
-  public options: google.maps.MapOptions = {
+  options: google.maps.MapOptions = {
     disableDefaultUI: true,
   };
-  public currentPosition: google.maps.LatLngLiteral;
-  public currentPositionMarkerOption = { draggable: false };
+  currentPosition: google.maps.LatLngLiteral;
+  currentPositionMarkerOption = { draggable: false };
 
-  public posts$: Observable<Post[]> = this.postService.getPosts();
-  public markerOptions = { draggable: false };
+  posts$: Observable<Post[]> = this.postService.getPosts();
+  markerOptions = { draggable: false };
 
   constructor(private postService: PostService, private router: Router) {}
 

--- a/src/app/shared/post-card/post-card.component.html
+++ b/src/app/shared/post-card/post-card.component.html
@@ -8,6 +8,26 @@
       ></div>
       <mat-card-title>{{ post.user.name }}</mat-card-title>
       <mat-card-subtitle>{{ post.category }}</mat-card-subtitle>
+      <ng-container *ngIf="user$ | async as user">
+        <button
+          *ngIf="user.uid === post.userId"
+          mat-icon-button
+          [matMenuTriggerFor]="menuRef"
+          class="card__edit"
+        >
+          <mat-icon>more_vert</mat-icon>
+        </button>
+        <mat-menu #menuRef="matMenu">
+          <button mat-menu-item (click)="editPost(post.id)">
+            <mat-icon>edit</mat-icon>
+            <span>編集する</span>
+          </button>
+          <button mat-menu-item (click)="deletePost(post.id)">
+            <mat-icon>delete</mat-icon>
+            <span>削除</span>
+          </button>
+        </mat-menu>
+      </ng-container>
     </mat-card-header>
     <a href="{{ post.imageURL }}">
       <div

--- a/src/app/shared/post-card/post-card.component.scss
+++ b/src/app/shared/post-card/post-card.component.scss
@@ -22,6 +22,11 @@
   &__avatar {
     background: center/cover;
   }
+  &__edit {
+    position: absolute;
+    top: 8px;
+    right: 0px;
+  }
   &__title {
     margin-bottom: 4px;
   }

--- a/src/app/shared/post-card/post-card.component.ts
+++ b/src/app/shared/post-card/post-card.component.ts
@@ -1,11 +1,14 @@
-import { Component, OnInit, Input, OnDestroy } from '@angular/core';
+import { Component, OnInit, Input, OnDestroy, Inject } from '@angular/core';
 import { PostWithUser } from 'src/app/interfaces/post';
 import { UserService } from 'src/app/services/user.service';
 import { PostService } from 'src/app/services/post.service';
 import { User } from 'src/app/interfaces/user';
 import { Observable, Subscription } from 'rxjs';
 import { tap } from 'rxjs/operators';
-import { MatSnackBar } from '@angular/material/snack-bar';
+import {
+  MatSnackBar,
+  MAT_SNACK_BAR_DEFAULT_OPTIONS,
+} from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 
 @Component({
@@ -22,7 +25,8 @@ export class PostCardComponent implements OnInit, OnDestroy {
     private userService: UserService,
     private postService: PostService,
     private snackBar: MatSnackBar,
-    private router: Router
+    private router: Router,
+    @Inject(MAT_SNACK_BAR_DEFAULT_OPTIONS) public data: any
   ) {}
 
   subscriptions: Subscription = new Subscription();
@@ -71,9 +75,11 @@ export class PostCardComponent implements OnInit, OnDestroy {
 
   deletePost(postId: string) {
     this.postService.deletePost(postId).then(() => {
-      this.snackBar.open('削除しました、反映にはリロードが必要です', null, {
-        duration: 3000,
-      });
+      this.snackBar.open(
+        '削除しました、反映にはリロードが必要です',
+        null,
+        this.data
+      );
     });
   }
 

--- a/src/app/shared/post-card/post-card.component.ts
+++ b/src/app/shared/post-card/post-card.component.ts
@@ -5,13 +5,13 @@ import { PostService } from 'src/app/services/post.service';
 import { User } from 'src/app/interfaces/user';
 import { Observable, Subscription } from 'rxjs';
 import { tap } from 'rxjs/operators';
-import { DatePipe } from '@angular/common';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-post-card',
   templateUrl: './post-card.component.html',
   styleUrls: ['./post-card.component.scss'],
-  providers: [DatePipe],
 })
 export class PostCardComponent implements OnInit, OnDestroy {
   @Input() post: PostWithUser;
@@ -21,7 +21,8 @@ export class PostCardComponent implements OnInit, OnDestroy {
   constructor(
     private userService: UserService,
     private postService: PostService,
-    private datePipe: DatePipe
+    private snackBar: MatSnackBar,
+    private router: Router
   ) {}
 
   subscriptions: Subscription = new Subscription();
@@ -58,6 +59,22 @@ export class PostCardComponent implements OnInit, OnDestroy {
     this.post.likeCount--;
     this.isLiked = false;
     return this.postService.unlikePost(postId, uid);
+  }
+
+  editPost(postId: string) {
+    this.router.navigate(['/form'], {
+      queryParams: {
+        id: postId,
+      },
+    });
+  }
+
+  deletePost(postId: string) {
+    this.postService.deletePost(postId).then(() => {
+      this.snackBar.open('削除しました、反映にはリロードが必要です', null, {
+        duration: 3000,
+      });
+    });
   }
 
   ngOnDestroy(): void {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -8,7 +8,10 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
+import {
+  MatSnackBarModule,
+  MAT_SNACK_BAR_DEFAULT_OPTIONS,
+} from '@angular/material/snack-bar';
 import { MatListModule } from '@angular/material/list';
 import { RouterModule } from '@angular/router';
 import { MatExpansionModule } from '@angular/material/expansion';
@@ -63,6 +66,9 @@ import { ConfirmDialogComponent } from './dialogs/confirm-dialog/confirm-dialog.
     PostCardComponent,
     GoogleMapSmallComponent,
     GoogleMapSmallComponent,
+  ],
+  providers: [
+    { provide: MAT_SNACK_BAR_DEFAULT_OPTIONS, useValue: { duration: 3000 } },
   ],
 })
 export class SharedModule {}


### PR DESCRIPTION
fix #150 
記事の編集・削除を実装しました。
ご確認お願い致します。

## 作業内容
- 編集メニュー作成
- 編集時フォームの初期値に記事の値を反映
- 更新用関数を作成

## Image
更新
[![Image from Gyazo](https://i.gyazo.com/fe781da8a611fb6b14aa4b0604a3de5d.gif)](https://gyazo.com/fe781da8a611fb6b14aa4b0604a3de5d)
削除
[![Image from Gyazo](https://i.gyazo.com/b2ae8a84670f67e730c2f8b3d348bfba.gif)](https://gyazo.com/b2ae8a84670f67e730c2f8b3d348bfba)
他人の記事には編集ボタンが出ないようにしている
![image](https://user-images.githubusercontent.com/60844124/93451987-d4044a80-f912-11ea-9687-2f2765ec42f4.png)

